### PR TITLE
Remove OpenMPI dependency

### DIFF
--- a/.github/workflows/ninja-ci.yml
+++ b/.github/workflows/ninja-ci.yml
@@ -3,10 +3,13 @@ name: NINJA CI
 on: [pull_request, push]
 
 jobs:
-  build:
+  check:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
 
-    runs-on: ubuntu-18.04
-    
+    runs-on: ${{ matrix.os }}
+
     steps:
     - uses: actions/checkout@v1
     - name: make check

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,9 @@
 SOURCES := $(wildcard NINJA/*.cpp)
 OBJECTS := $(SOURCES:.cpp=.o)
 
-# TODO: get newer GCC versions to work
 # The C++ compiler must support C++11
-CXX := g++-7
-# TODO: eliminate the need for openmp so we can use Apple Clang
-CXXFLAGS := -std=gnu++11 -Wall -mssse3 -fopenmp
+CXX := g++
+CXXFLAGS := -std=gnu++11 -Wall -mssse3
 
 # TODO: build to a dist directory or similar
 # TODO: use separate release and debug build directories
@@ -48,10 +46,8 @@ docs:
 
 .PHONY: setup-mac
 setup-mac:
-	brew install pipenv
-	brew install pyenv
-	brew install gcc@7
 	brew install doxygen
-	pyenv install -s 3.8.3
+	brew install pipenv
+	brew install python
 	pipenv sync --dev
 	@echo 'Use `pipenv shell` to start the virtual environment'

--- a/NINJA/DistanceCalculator.hpp
+++ b/NINJA/DistanceCalculator.hpp
@@ -9,7 +9,6 @@
 #include <emmintrin.h>        /* SSE2 */
 #include <tmmintrin.h>      /* SSE3 */
 #include <cstdint>
-#include <omp.h> /* openmp */
 
 
 class DistanceCalculator {

--- a/NINJA/DistanceReader.cpp
+++ b/NINJA/DistanceReader.cpp
@@ -59,13 +59,8 @@ void DistanceReader::read(std::string **names,
     unsigned int begin = 0, end = 0, numBegin = 0, numEnd = 0;
     int count = 0;
 
-    if (this->threads == 0) {
-        omp_set_num_threads(omp_get_max_threads());
-    } else {
-        omp_set_num_threads(this->threads);
-    }
+    // TODO: We may want to parallelize this in the future
     if (this->distCalc != nullptr) {//using distCalc on input alignment
-#pragma omp parallel for
         for (int i = 0; i < this->K; i++)
             for (int j = i + 1; j < this->K; j++) {
                 //distances[i][j-i-1] = this->distCalc->testDifferenceCluster(i,j);
@@ -119,12 +114,7 @@ void DistanceReader::readAndWrite(std::string **names,
     for (int i = 0; i < this->K; ++i)
         distances[i] = new double[this->K];
 
-    if (this->threads == 0) {
-        omp_set_num_threads(omp_get_max_threads());
-    } else {
-        omp_set_num_threads(this->threads);
-    }
-#pragma omp parallel for
+    // TODO: We may want to parallelize this in the future
     for (int i = 0; i < this->K; i++) {
         for (int j = i + 1; j < this->K; j++) {
             //distances[i][j-i-1] = this->distCalc->testDifferenceCluster(i,j);

--- a/NINJA/DistanceReader.hpp
+++ b/NINJA/DistanceReader.hpp
@@ -1,5 +1,5 @@
-#include "ExceptionHandler.hpp"
 #include "DistanceCalculator.hpp"
+#include "ExceptionHandler.hpp"
 
 class DistanceReader {
 public:

--- a/NINJA/DistanceReaderExtMem.cpp
+++ b/NINJA/DistanceReaderExtMem.cpp
@@ -38,21 +38,17 @@ int DistanceReaderExtMem::read(std::string **names, float *R, FILE *diskD, float
 
     float *fBuff = new float[numColsToDisk];
 
-    omp_set_num_threads(omp_get_max_threads());
-
-    //TODO: implement threads here, more complicated that in the in memory function, but still feasible
     if (this->distCalc != nullptr) {
         while (row != K && buffPtr < buffSize) {
 
+            // TODO: May want to parallelize this loop
             //interleave columns in the
-#pragma omp parallel for
             for (int col = 0; col < numColsToDisk; col++) {
 
                 float d = ((float) ceil((float) (10000000 * distCalc->calc(row, col)))) / 10000000;
 
-#pragma omp atomic
+                // TODO: The next two instructions must be atomic
                 R[row] += d;
-
                 fBuff[col] = d;
 
             }
@@ -63,18 +59,17 @@ int DistanceReaderExtMem::read(std::string **names, float *R, FILE *diskD, float
                 fwrite(fBuff, sizeof(float), numColsToDisk, diskD);
 
             }
-#pragma omp parallel for
+
+            // TODO: May want to parallelize this loop
             for (int col = numColsToDisk; col < this->K; col++) {
 #ifdef TEST_DIFF
                 float d = this->distCalc->testDifferenceCluster(row,col);
 #endif
                 float d = ((float) ceil((float) (10000000 * distCalc->calc(row, col)))) / 10000000;
 
-#pragma omp atomic
+                // TODO: The next two instructions must be atomic
                 R[row] += d;
-
                 memD[row][col - numColsToDisk] = d;
-
             }
 
             row++;

--- a/NINJA/TreeBuilderExtMem.hpp
+++ b/NINJA/TreeBuilderExtMem.hpp
@@ -7,7 +7,7 @@
 #include "TreeNode.hpp"
 
 #include <cfloat>
-#include <tr1/unordered_set>
+#include <unordered_map>
 
 class CandidateHeap;
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
 # NINJA
+
 Nearly Infinite Neighbor Joining Application
 
 ## About
+
 TODO: Information from Travis... history, Java version, publication(s)
 
 ## Development
+
 Clone the code. If you're on a Mac, you can run `make setup-mac` to install most
 of the required tools through [Homebrew](http://brew.sh). This includes:
 
-  - [pipenv](https://github.com/pypa/pipenv)
-  - [pyenv](https://github.com/pyenv/pyenv)
-  - [GCC 6](https://gcc.gnu.org)
   - [compiledb](https://github.com/nickdiego/compiledb)
-
-Right now, the codebase uses [OpenMPI](https://www.open-mpi.org) which is not
-included in the default C++ toolchain included with XCode on macOS. The easiest
-way to get around this, at the moment, is to build with GCC. In the future, we
-hope to eliminate the OpenMPI dependency so that the Mac version of Clang will
-be able to build NINJA.
+  - [doxygen](https://www.doxygen.nl)
+  - [pipenv](https://github.com/pypa/pipenv)
+  - Python 3.8 or greater
 
 Contributions are welcomed. To do this, fork the repo, create a branch and, once
 you're ready, create a pull request from your branch into the `master` branch in

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -2,11 +2,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -18,11 +17,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -34,11 +32,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -50,11 +47,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -66,11 +62,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -82,11 +77,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -98,11 +92,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -114,11 +107,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -130,11 +122,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -146,11 +137,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -162,11 +152,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -178,11 +167,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -194,11 +182,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -210,11 +197,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -226,11 +212,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -242,11 +227,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -258,11 +242,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -274,11 +257,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",
@@ -290,11 +272,10 @@
  {
   "directory": "/Users/george/Code/traviswheelerlab/NINJA",
   "arguments": [
-   "g++-7",
+   "g++",
    "-std=gnu++11",
    "-Wall",
    "-mssse3",
-   "-fopenmp",
    "-O3",
    "-c",
    "-o",


### PR DESCRIPTION
Since macOS doesn't ship with OpenMPI (they remove it from the version of Clang they include) we'd rather not use it here because we expect a decent share of our users to be on Macs. This de-parallelizes the parts of the code that had been using OpenMPI and leaves behind some notes to guide future work re-implementing the parallelism.

As a side bonus, all new-ish versions of GCC should now also work, and the specific GCC version reference in the Makefile has been removed.